### PR TITLE
Fix/match duplicate children

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovyih/x-tree-diff-plus",
-  "version": "0.1.3-alpha.3",
+  "version": "0.1.3",
   "description": "A implementation for *X-tree Diff +: An Efficient Change Detection Algorithm for Tree-structured Data*",
   "private": false,
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovyih/x-tree-diff-plus",
-  "version": "0.1.2",
+  "version": "0.1.3-alph.1",
   "description": "A implementation for *X-tree Diff +: An Efficient Change Detection Algorithm for Tree-structured Data*",
   "private": false,
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovyih/x-tree-diff-plus",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A implementation for *X-tree Diff +: An Efficient Change Detection Algorithm for Tree-structured Data*",
   "private": false,
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovyih/x-tree-diff-plus",
-  "version": "0.1.3-alph.1",
+  "version": "0.1.3-alpha.3",
   "description": "A implementation for *X-tree Diff +: An Efficient Change Detection Algorithm for Tree-structured Data*",
   "private": false,
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dovyih/x-tree-diff-plus",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A implementation for *X-tree Diff +: An Efficient Change Detection Algorithm for Tree-structured Data*",
   "private": false,
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint --ext .ts --fix src/",
     "test": "jest",
     "ts": "ts-node",
-    "prepublishOnly": "yarn build",
+    "prepublishOnly": "yarn test && yarn build",
     "build": "rm -fr dsit && tsc --build tsconfig.json"
   },
   "lint-staged": {

--- a/src/XTreeDiffPlus.spec.ts
+++ b/src/XTreeDiffPlus.spec.ts
@@ -10,24 +10,24 @@
  * Copyright 2019 - 2019 Mozilla Public License 2.0                          *
  *-------------------------------------------------------------------------- */
 
-import { createTree31 , createTree32, createTree33, createTree34, createTree35 , createTree36 } from '../test/nested'
-import { XTreeDiffPlus }                                                                                                                                             from './XTreeDiffPlus';
-import { EditOption }                                                                                                                                                from './EditOption';
-import { createTree01, createTree02, createTree03, createTree05, createTree04, createTree06, createTree07, createTree08, createTree09, createTree010, createTree011} from '../test/three-nodes';
-import { createOldTree, createNewTree }                                                                                                                              from '../test/tune-existing-matches'
+import { createTree31, createTree32, createTree33, createTree34, createTree35, createTree36 } from '../test/nested'
+import { XTreeDiffPlus } from './XTreeDiffPlus';
+import { EditOption } from './EditOption';
+import { createTree01, createTree02, createTree03, createTree05, createTree04, createTree06, createTree07, createTree08, createTree09, createTree010, createTree011 } from '../test/three-nodes';
+import { createOldTree, createNewTree } from '../test/tune-existing-matches'
 // import createTree1 from '../test/tree1';
 // import createTree2 from '../test/tree2';
 // imporkkt createTree3 from '../test/tree3';
-import { XTree }                                                                                                                                                     from './XTree';
-import { createTree11, createTree12 }                                                                                                                                from '../test/duplicate';
-import { createTree22, createTree21, createTree23 }                                                                                                                  from '../test/text-ndoe';
+import { XTree } from './XTree';
+import { createTree11, createTree12, createTree13 } from '../test/duplicate';
+import { createTree22, createTree21, createTree23 } from '../test/text-ndoe';
 
 class DefaultXTreeDiff extends XTreeDiffPlus<XTree, XTree> {
   public buildXTree(tree: XTree) {
     return tree;
   }
 
-  public dumpXTree(oldTree: XTree, newTree: XTree): { oldTree: XTree, newTree: XTree} {
+  public dumpXTree(oldTree: XTree, newTree: XTree): { oldTree: XTree, newTree: XTree } {
     return { oldTree, newTree };
   }
 }
@@ -111,7 +111,7 @@ describe('three nodes', () => {
     expect(newTree.getChild(0)?.Op).toBe(EditOption.INS);
     expect(newTree.getChild(1)?.Op).toBe(EditOption.INS);
   });
-  
+
   test('tree 9 this first child different from tree7', () => {
     const oldTree = createTree07();
     const newTree = createTree09();
@@ -156,7 +156,7 @@ describe('three nodes', () => {
 
 
 describe('standard case', () => {
-  test('tune existing matches',() => {
+  test('tune existing matches', () => {
     const oldTree = createOldTree();
     const newTree = createNewTree();
     const xTreeDiff = new DefaultXTreeDiff(oldTree, newTree);
@@ -184,460 +184,318 @@ describe('duplicate node', () => {
   });
 
   test('the second child of these trees are not the same', () => {
-    const oldTree   = createTree11 ()
-    const newTree   = createTree12 ()
-    const xTreeDiff = new DefaultXTreeDiff (
-      oldTree ,
+    const oldTree = createTree11()
+    const newTree = createTree12()
+    const xTreeDiff = new DefaultXTreeDiff(
+      oldTree,
       newTree
     )
-    xTreeDiff.diff ()
+    xTreeDiff.diff()
 
-    expect ( oldTree.Op )
-      .toBe ( EditOption.NOP )
-    expect ( newTree.Op )
-      .toBe ( EditOption.NOP )
+    expect(oldTree.Op).toBe(EditOption.NOP)
+    expect(newTree.Op).toBe(EditOption.NOP)
 
-    expect ( newTree.getChild ( 0 )!.Op )
-      .toBe ( EditOption.NOP )
-    expect ( newTree.getChild ( 1 )!.Op )
-      .toBe ( EditOption.UPD )
-  } );
+    expect(newTree.getChild(0)!.Op).toBe(EditOption.NOP)
+    expect(newTree.getChild(1)!.Op).toBe(EditOption.UPD)
+  });
 
-  describe (
-    'text node' ,
+  describe('text node', () => {
+    test('the secode text are diffirent', () => {
+      const oldTree = createTree21()
+      const newTree = createTree22()
+      const xTreeDiff = new DefaultXTreeDiff(
+        oldTree,
+        newTree
+      )
+      xTreeDiff.diff()
+      expect(newTree.getChild(1)!.getChild(0)!.Op).toBe(EditOption.UPD)
+      expect(oldTree.getChild(1)!.getChild(0)!.Op).toBe(EditOption.UPD)
+    });
+
+    test('oldTree two text node are the same,but newTree not', () => {
+      const oldTree = createTree23()
+      const newTree = createTree21()
+      const xTreeDiff = new DefaultXTreeDiff(
+        oldTree,
+        newTree
+      )
+      xTreeDiff.diff()
+      expect(newTree.getChild(1)!.getChild(0)!.Op).toBe(EditOption.UPD)
+      expect(oldTree.getChild(1)!.getChild(0)!.Op).toBe(EditOption.UPD)
+    });
+  });
+
+});
+
+describe('nested nodes', () => {
+  test('inserting a element node in between of some text nodes', () => {
+    // old Tree:  <div>This is a good test.</div>
+    const oldTree = createTree31()
+
+    // new Tree:  <div>This is a<b>very good</b>test.</div>
+    const newTree = createTree32()
+
+    const xTreeDiff = new DefaultXTreeDiff(
+      oldTree,
+      newTree
+    )
+
+
+    xTreeDiff.diff()
+
+    expect(oldTree.Op).toBe(EditOption.NOP)
+    expect(newTree.Op).toBe(EditOption.NOP)
+
+    // This 
+    const This = newTree?.getChild(0)?.getChild(0)
+    expect(This?.nPtr).toBe(oldTree?.getChild(0)?.getChild(0))
+
+    // is 
+    const is = newTree?.getChild(0)?.getChild(1)
+    expect(is?.nPtr).toBe(oldTree?.getChild(0)?.getChild(1))
+
+    // a 
+    const a = newTree?.getChild(0)?.getChild(2)
+    expect(a?.nPtr).toBe(oldTree?.getChild(0)?.getChild(2))
+
+    expect(newTree?.getChild(0)?.getChild(3)).toBeNull()
+
+
+    // <b>very good</b> 
+    const B = newTree?.getChild(1)
+    expect(B?.label).toBe('B')
+
+    expect(B?.getChild(0)?.value).toBe('very')
+    expect(B?.getChild(0)?.Op).toBe(EditOption.INS)
+
+    expect(B?.getChild(1)?.value).toBe('good')
+    expect(B?.getChild(1)?.Op).toBe(EditOption.MOV)
+
+    expect(B?.getChild(1)?.nPtr).toBe(oldTree?.getChild(0)?.getChild(3))
+
+    // test. 
+    const test = newTree?.getChild(2)?.getChild(0)
+    expect(test?.nPtr).toBe(oldTree?.getChild(0)?.getChild(4))
+  }
+  )
+
+  test(
+    'inserting a element node in between of some text nodes and modify the first text node',
     () => {
-      test (
-        'the secode text are diffirent' ,
-        () => {
-          const oldTree   = createTree21 ()
-          const newTree   = createTree22 ()
-          const xTreeDiff = new DefaultXTreeDiff (
-            oldTree ,
-            newTree
-          )
-          xTreeDiff.diff ()
-          expect ( newTree.getChild ( 1 )!.getChild ( 0 )!.Op )
-            .toBe ( EditOption.UPD )
-          expect ( oldTree.getChild ( 1 )!.getChild ( 0 )!.Op )
-            .toBe ( EditOption.UPD )
-        }
+      // old Tree:  <div>This is a good test.</div>
+      const oldTree = createTree31()
+
+      // new Tree:  <div>These is a<b>very good</b>test.</div>
+      const newTree = createTree33()
+
+      const xTreeDiff = new DefaultXTreeDiff(
+        oldTree,
+        newTree
       )
 
-      test (
-        'oldTree two text node are the same,but newTree not' ,
-        () => {
-          const oldTree   = createTree23 ()
-          const newTree   = createTree21 ()
-          const xTreeDiff = new DefaultXTreeDiff (
-            oldTree ,
-            newTree
-          )
-          xTreeDiff.diff ()
-          expect ( newTree.getChild ( 1 )!.getChild ( 0 )!.Op )
-            .toBe ( EditOption.UPD )
-          expect ( oldTree.getChild ( 1 )!.getChild ( 0 )!.Op )
-            .toBe ( EditOption.UPD )
-        }
-      )
+
+      xTreeDiff.diff()
+
+      expect(oldTree.Op).toBe(EditOption.NOP)
+      expect(newTree.Op).toBe(EditOption.NOP)
+
+      // This 
+      const This = newTree?.getChild(0)?.getChild(0)
+      expect(This?.nPtr).toBe(oldTree?.getChild(0)?.getChild(0))
+
+      // is 
+      const is = newTree?.getChild(0)?.getChild(1)
+      expect(is?.nPtr).toBe(oldTree?.getChild(0)?.getChild(1))
+
+      // a 
+      const a = newTree?.getChild(0)?.getChild(2)
+      expect(a?.nPtr).toBe(oldTree?.getChild(0)?.getChild(2))
+
+      expect(newTree?.getChild(0)?.getChild(3)).toBeNull()
+
+
+      // <b>very good</b> 
+      const B = newTree?.getChild(1)
+      expect(B?.label).toBe('B')
+
+      expect(B?.getChild(0)?.value).toBe('very')
+      expect(B?.getChild(0)?.Op).toBe(EditOption.INS)
+
+      expect(B?.getChild(1)?.value).toBe('good')
+      expect(B?.getChild(1)?.Op).toBe(EditOption.MOV)
+
+      expect(B?.getChild(1)?.nPtr).toBe(oldTree?.getChild(0)?.getChild(3))
+
+      // test. 
+      const test = newTree?.getChild(2)?.getChild(0)
+      expect(test?.nPtr).toBe(oldTree?.getChild(0)?.getChild(4))
     }
   )
-} );
-
-describe (
-  'nested nodes' ,
-  () => {
-    test (
-      'inserting a element node in between of some text nodes' ,
-      () => {
-        // old Tree:  <div>This is a good test.</div>
-        const oldTree = createTree31 ()
-
-        // new Tree:  <div>This is a<b>very good</b>test.</div>
-        const newTree = createTree32 ()
-
-        const xTreeDiff = new DefaultXTreeDiff (
-          oldTree ,
-          newTree
-        )
 
 
-        xTreeDiff.diff ()
 
-        expect ( oldTree.Op )
-          .toBe ( EditOption.NOP )
-        expect ( newTree.Op )
-          .toBe ( EditOption.NOP )
+  test('inserting a element node between some text nodes and modify the first two text node', () => {
+    // old Tree:  <div>This is a good test.</div>
+    const oldTree = createTree31()
 
-        // This 
-        const This = newTree?.getChild ( 0 )
-                            ?.getChild ( 0 )
-        expect ( This?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 0 ) )
+    // new Tree:  <div>These are a<b>very good</b>test.</div>
+    const newTree = createTree34()
 
-        // is 
-        const is = newTree?.getChild ( 0 )
-                          ?.getChild ( 1 )
-        expect ( is?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 1 ) )
-
-        // a 
-        const a = newTree?.getChild ( 0 )
-                         ?.getChild ( 2 )
-        expect ( a?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 2 ) )
-
-        expect ( newTree?.getChild ( 0 )
-                        ?.getChild ( 3 ) )
-          .toBeNull ()
-
-
-        // <b>very good</b> 
-        const B = newTree?.getChild ( 1 )
-        expect ( B?.label )
-          .toBe ( 'B' )
-
-        expect ( B?.getChild ( 0 )?.value )
-          .toBe ( 'very' )
-        expect ( B?.getChild ( 0 )?.Op )
-          .toBe ( EditOption.INS )
-
-        expect ( B?.getChild ( 1 )?.value )
-          .toBe ( 'good' )
-        expect ( B?.getChild ( 1 )?.Op )
-          .toBe ( EditOption.MOV )
-
-        expect ( B?.getChild ( 1 )?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 3 ) )
-
-        // test. 
-        const test = newTree?.getChild ( 2 )
-                            ?.getChild ( 0 )
-        expect ( test?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 4 ) )
-      }
-    )
-
-    test (
-      'inserting a element node in between of some text nodes and modify the first text node' ,
-      () => {
-        // old Tree:  <div>This is a good test.</div>
-        const oldTree = createTree31 ()
-
-        // new Tree:  <div>These is a<b>very good</b>test.</div>
-        const newTree = createTree33 ()
-
-        const xTreeDiff = new DefaultXTreeDiff (
-          oldTree ,
-          newTree
-        )
-
-
-        xTreeDiff.diff ()
-
-        expect ( oldTree.Op )
-          .toBe ( EditOption.NOP )
-        expect ( newTree.Op )
-          .toBe ( EditOption.NOP )
-
-        // This 
-        const This = newTree?.getChild ( 0 )
-                            ?.getChild ( 0 )
-        expect ( This?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 0 ) )
-
-        // is 
-        const is = newTree?.getChild ( 0 )
-                          ?.getChild ( 1 )
-        expect ( is?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 1 ) )
-
-        // a 
-        const a = newTree?.getChild ( 0 )
-                         ?.getChild ( 2 )
-        expect ( a?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 2 ) )
-
-        expect ( newTree?.getChild ( 0 )
-                        ?.getChild ( 3 ) )
-          .toBeNull ()
-
-
-        // <b>very good</b> 
-        const B = newTree?.getChild ( 1 )
-        expect ( B?.label )
-          .toBe ( 'B' )
-
-        expect ( B?.getChild ( 0 )?.value )
-          .toBe ( 'very' )
-        expect ( B?.getChild ( 0 )?.Op )
-          .toBe ( EditOption.INS )
-
-        expect ( B?.getChild ( 1 )?.value )
-          .toBe ( 'good' )
-        expect ( B?.getChild ( 1 )?.Op )
-          .toBe ( EditOption.MOV )
-
-        expect ( B?.getChild ( 1 )?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 3 ) )
-
-        // test. 
-        const test = newTree?.getChild ( 2 )
-                            ?.getChild ( 0 )
-        expect ( test?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 4 ) )
-      }
+    const xTreeDiff = new DefaultXTreeDiff(
+      oldTree,
+      newTree
     )
 
 
-
-    test (
-      'inserting a element node between some text nodes and modify the first two text node' ,
-      () => {
-        // old Tree:  <div>This is a good test.</div>
-        const oldTree = createTree31 ()
-
-        // new Tree:  <div>These are a<b>very good</b>test.</div>
-        const newTree = createTree34 ()
-
-        const xTreeDiff = new DefaultXTreeDiff (
-          oldTree ,
-          newTree
-        )
+    xTreeDiff.diff()
 
 
-        xTreeDiff.diff ()
+    expect(oldTree.Op).toBe(EditOption.NOP)
+    expect(newTree.Op).toBe(EditOption.NOP)
+
+    // This 
+    const This = newTree?.getChild(0)?.getChild(0)
+    expect(This?.nPtr).toBe(oldTree?.getChild(0)?.getChild(0))
+
+    expect(This?.Op).toBe(EditOption.UPD)
+
+    // is 
+    const is = newTree?.getChild(0)?.getChild(1)
+    expect(is?.nPtr).toBe(oldTree?.getChild(0)?.getChild(1))
+
+    expect(is?.Op).toBe(EditOption.UPD)
+
+    // a 
+    const a = newTree?.getChild(0)?.getChild(2)
+    expect(a?.nPtr).toBe(oldTree?.getChild(0)?.getChild(2))
+
+    expect(newTree?.getChild(0)?.getChild(3)).toBeNull()
 
 
-        expect ( oldTree.Op )
-          .toBe ( EditOption.NOP )
-        expect ( newTree.Op )
-          .toBe ( EditOption.NOP )
+    // <b>very good</b> 
+    const B = newTree?.getChild(1)
+    expect(B?.label).toBe('B')
 
-        // This 
-        const This = newTree?.getChild ( 0 )
-                            ?.getChild ( 0 )
-        expect ( This?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 0 ) )
+    expect(B?.getChild(0)?.value).toBe('very')
+    expect(B?.getChild(0)?.Op).toBe(EditOption.INS)
 
-        expect ( This?.Op )
-          .toBe ( EditOption.UPD )
-        
-        // is 
-        const is = newTree?.getChild ( 0 )
-                          ?.getChild ( 1 )
-        expect ( is?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 1 ) )
+    expect(B?.getChild(1)?.value).toBe('good')
+    expect(B?.getChild(1)?.Op).toBe(EditOption.MOV)
 
-        expect ( is?.Op )
-          .toBe ( EditOption.UPD )
-        
-        // a 
-        const a = newTree?.getChild ( 0 )
-                         ?.getChild ( 2 )
-        expect ( a?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 2 ) )
+    expect(B?.getChild(1)?.nPtr).toBe(oldTree?.getChild(0)?.getChild(3))
 
-        expect ( newTree?.getChild ( 0 )
-                        ?.getChild ( 3 ) )
-          .toBeNull ()
+    // test. 
+    const test = newTree?.getChild(2)?.getChild(0)
+    expect(test?.nPtr).toBe(oldTree?.getChild(0)?.getChild(4))
+  });
 
 
-        // <b>very good</b> 
-        const B = newTree?.getChild ( 1 )
-        expect ( B?.label )
-          .toBe ( 'B' )
 
-        expect ( B?.getChild ( 0 )?.value )
-          .toBe ( 'very' )
-        expect ( B?.getChild ( 0 )?.Op )
-          .toBe ( EditOption.INS )
+  test('inserting a element node between some text nodes and modify the beginning and the end.', () => {
+    // old Tree:  <div>This is a good test.</div>
+    const oldTree = createTree31()
 
-        expect ( B?.getChild ( 1 )?.value )
-          .toBe ( 'good' )
-        expect ( B?.getChild ( 1 )?.Op )
-          .toBe ( EditOption.MOV )
+    // new Tree:  <div>These are some<b>very good</b>test.</div>
+    const newTree = createTree35()
 
-        expect ( B?.getChild ( 1 )?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 3 ) )
-
-        // test. 
-        const test = newTree?.getChild ( 2 )
-                            ?.getChild ( 0 )
-        expect ( test?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 4 ) )
-      }
+    const xTreeDiff = new DefaultXTreeDiff(
+      oldTree,
+      newTree
     )
 
 
-
-    test (
-      'inserting a element node between some text nodes and modify the beginning and the end.' ,
-      () => {
-        // old Tree:  <div>This is a good test.</div>
-        const oldTree = createTree31 ()
-
-        // new Tree:  <div>These are some<b>very good</b>test.</div>
-        const newTree = createTree35 ()
-
-        const xTreeDiff = new DefaultXTreeDiff (
-          oldTree ,
-          newTree
-        )
+    xTreeDiff.diff()
 
 
-        xTreeDiff.diff ()
+    expect(oldTree.Op).toBe(EditOption.NOP)
+    expect(newTree.Op).toBe(EditOption.NOP)
+
+    // This 
+    const This = newTree?.getChild(0)?.getChild(0)
+    expect(This?.nPtr).toBe(oldTree?.getChild(0)?.getChild(0))
+
+    expect(This?.Op).toBe(EditOption.UPD)
+
+    // is 
+    const is = newTree?.getChild(0)?.getChild(1)
+    expect(is?.nPtr).toBe(oldTree?.getChild(0)?.getChild(1))
+
+    expect(is?.Op).toBe(EditOption.UPD)
+
+    // a 
+    const a = newTree?.getChild(0)?.getChild(2)
+    expect(a?.nPtr).toBe(oldTree?.getChild(0)?.getChild(2))
+
+    expect(newTree?.getChild(0)?.getChild(3)).toBeNull()
 
 
-        expect ( oldTree.Op )
-          .toBe ( EditOption.NOP )
-        expect ( newTree.Op )
-          .toBe ( EditOption.NOP )
+    // <b>very good</b> 
+    const B = newTree?.getChild(1)
+    expect(B?.label).toBe('B')
 
-        // This 
-        const This = newTree?.getChild ( 0 )
-                            ?.getChild ( 0 )
-        expect ( This?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 0 ) )
+    expect(B?.getChild(0)?.value).toBe('very')
+    expect(B?.getChild(0)?.Op).toBe(EditOption.INS)
 
-        expect ( This?.Op )
-          .toBe ( EditOption.UPD )
+    expect(B?.getChild(1)?.value).toBe('good')
+    expect(B?.getChild(1)?.Op).toBe(EditOption.MOV)
 
-        // is 
-        const is = newTree?.getChild ( 0 )
-                          ?.getChild ( 1 )
-        expect ( is?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 1 ) )
+    expect(B?.getChild(1)?.nPtr).toBe(oldTree?.getChild(0)?.getChild(3))
 
-        expect ( is?.Op )
-          .toBe ( EditOption.UPD )
-
-        // a 
-        const a = newTree?.getChild ( 0 )
-                         ?.getChild ( 2 )
-        expect ( a?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 2 ) )
-
-        expect ( newTree?.getChild ( 0 )
-                        ?.getChild ( 3 ) )
-          .toBeNull ()
+    // test. 
+    const test = newTree?.getChild(2)?.getChild(0)
+    expect(test?.value).toBe('tests.')
+    expect(test?.Op).toBe(EditOption.INS)
+  })
 
 
-        // <b>very good</b> 
-        const B = newTree?.getChild ( 1 )
-        expect ( B?.label )
-          .toBe ( 'B' )
+  test('modify the entire sentence, except for the word in the new inserted element node', () => {
+    // old Tree:  <div>This is a good test.</div>
+    const oldTree = createTree31()
 
-        expect ( B?.getChild ( 0 )?.value )
-          .toBe ( 'very' )
-        expect ( B?.getChild ( 0 )?.Op )
-          .toBe ( EditOption.INS )
+    // new Tree:  <div>These are some<b>very good</b>test.</div>
+    const newTree = createTree36()
 
-        expect ( B?.getChild ( 1 )?.value )
-          .toBe ( 'good' )
-        expect ( B?.getChild ( 1 )?.Op )
-          .toBe ( EditOption.MOV )
-
-        expect ( B?.getChild ( 1 )?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 3 ) )
-
-        // test. 
-        const test = newTree?.getChild ( 2 )
-                            ?.getChild ( 0 )
-        expect ( test?.value )
-          .toBe ( 'tests.' )
-        expect ( test?.Op )
-          .toBe ( EditOption.INS )
-      }
+    const xTreeDiff = new DefaultXTreeDiff(
+      oldTree,
+      newTree
     )
 
 
-    test (
-      'modify the entire sentence, except for the word in the new inserted element node' ,
-      () => {
-        // old Tree:  <div>This is a good test.</div>
-        const oldTree = createTree31 ()
-
-        // new Tree:  <div>These are some<b>very good</b>test.</div>
-        const newTree = createTree36 ()
-
-        const xTreeDiff = new DefaultXTreeDiff (
-          oldTree ,
-          newTree
-        )
+    xTreeDiff.diff()
 
 
-        xTreeDiff.diff ()
+    expect(oldTree.Op).toBe(EditOption.DEL)
+    expect(newTree.Op).toBe(EditOption.INS)
+
+    // These 
+    const These = newTree?.getChild(0)?.getChild(0)
+    expect(These?.Op).toBe(EditOption.INS)
+
+    // are 
+    const are = newTree?.getChild(0)?.getChild(1)
+    expect(are?.Op).toBe(EditOption.INS)
+
+    // some 
+    const some = newTree?.getChild(0)?.getChild(2)
+
+    expect(some?.Op).toBe(EditOption.INS)
 
 
-        expect ( oldTree.Op )
-          .toBe ( EditOption.DEL )
-        expect ( newTree.Op )
-          .toBe ( EditOption.INS )
+    // <b>very good</b> 
+    const B = newTree?.getChild(1)
+    expect(B?.label).toBe('B')
 
-        // These 
-        const These = newTree?.getChild ( 0 )
-                            ?.getChild ( 0 )
-        expect ( These?.Op )
-          .toBe ( EditOption.INS )
+    expect(B?.getChild(0)?.value).toBe('very')
+    expect(B?.getChild(0)?.Op).toBe(EditOption.INS)
 
-        // are 
-        const are = newTree?.getChild ( 0 )
-                           ?.getChild ( 1 )
-        expect ( are?.Op )
-          .toBe ( EditOption.INS )
+    expect(B?.getChild(1)?.value).toBe('good')
+    expect(B?.getChild(1)?.Op).toBe(EditOption.MOV)
 
-        // some 
-        const some = newTree?.getChild ( 0 )
-                         ?.getChild ( 2 )
-        
-        expect ( some?.Op )
-          .toBe ( EditOption.INS )
+    expect(B?.getChild(1)?.nPtr).toBe(oldTree?.getChild(0)?.getChild(3))
 
+    // tests. 
+    const tests = newTree?.getChild(2)?.getChild(0)
+    expect(tests?.Op).toBe(EditOption.INS)
+  })
 
-        // <b>very good</b> 
-        const B = newTree?.getChild ( 1 )
-        expect ( B?.label )
-          .toBe ( 'B' )
-
-        expect ( B?.getChild ( 0 )?.value )
-          .toBe ( 'very' )
-        expect ( B?.getChild ( 0 )?.Op )
-          .toBe ( EditOption.INS )
-
-        expect ( B?.getChild ( 1 )?.value )
-          .toBe ( 'good' )
-        expect ( B?.getChild ( 1 )?.Op )
-          .toBe ( EditOption.MOV )
-
-        expect ( B?.getChild ( 1 )?.nPtr )
-          .toBe ( oldTree?.getChild ( 0 )
-                         ?.getChild ( 3 ) )
-
-        // tests. 
-        const tests = newTree?.getChild ( 2 )
-                            ?.getChild ( 0 )
-        expect ( tests?.Op )
-          .toBe ( EditOption.INS )
-      }
-    )
-
-  } );
+});

--- a/src/XTreeDiffPlus.spec.ts
+++ b/src/XTreeDiffPlus.spec.ts
@@ -183,6 +183,29 @@ describe('duplicate node', () => {
     expect(newTree.getChild(1)!.getChild(1)!.Op).toBe(EditOption.NOP);
   });
 
+  test('all three child are the same', () => {
+    const oldTree = createTree13();
+    const newTree = createTree13();
+    const xTreeDiff = new DefaultXTreeDiff(oldTree, newTree);
+    xTreeDiff.diff();
+
+    expect(oldTree.Op).toBe(EditOption.NOP);
+    expect(newTree.Op).toBe(EditOption.NOP);
+
+
+    expect(newTree.getChild(0)!.Op).toBe(EditOption.NOP);
+    expect(newTree.getChild(1)!.Op).toBe(EditOption.NOP);
+    expect(newTree.getChild(2)!.Op).toBe(EditOption.NOP);
+    
+    expect(oldTree.getChild(0)!.Op).toBe(EditOption.NOP);
+    expect(oldTree.getChild(1)!.Op).toBe(EditOption.NOP);
+    expect(oldTree.getChild(2)!.Op).toBe(EditOption.NOP);
+
+    expect(newTree.getChild(0)!.nPtr).toBe(oldTree.getChild(0));
+    expect(newTree.getChild(1)!.nPtr).toBe(oldTree.getChild(1));
+    expect(newTree.getChild(2)!.nPtr).toBe(oldTree.getChild(2));
+  });
+
   test('the second child of these trees are not the same', () => {
     const oldTree = createTree11()
     const newTree = createTree12()

--- a/src/XTreeDiffPlus.ts
+++ b/src/XTreeDiffPlus.ts
@@ -232,7 +232,7 @@ export abstract class XTreeDiffPlus<T = any, S= any> {
         });
 
         for (let bIdx = 0; bIdx < cB.length; bIdx++) {
-          const aIdx = cA.findIndex(chidA => chidA.tMD === cB[bIdx].tMD);
+          const aIdx = cA.findIndex(chidA => chidA.Op === null && chidA.tMD === cB[bIdx].tMD);
           if (aIdx !== -1) {
             // sub-tree is eaual, so mark sub-tree as NOP
             this.matchNodeSubtreeWith(cA[aIdx], cB[bIdx], EditOption.NOP);

--- a/test/duplicate.ts
+++ b/test/duplicate.ts
@@ -100,3 +100,29 @@ export function createTree12(): XTree {
     ],
   });
 }
+
+
+export function createTree13(): XTree {
+  return new XTree({
+    label: 'a',
+    type: NodeType.ELEMENT,
+    index: 1,
+    children: [
+      new XTree({
+        label: 'b',
+        type: NodeType.ELEMENT,
+        index: 1,
+      }),
+      new XTree({
+        label: 'b',
+        type: NodeType.ELEMENT,
+        index: 2,
+      }),
+      new XTree({
+        label: 'b',
+        type: NodeType.ELEMENT,
+        index: 2,
+      }),
+    ],
+  });
+}


### PR DESCRIPTION
fix match below:

```html
<div>               |   <div>              
    <span></span>   |      <span></span>
    <span></span>   |      <span></span>
    <span></span>   |      <span></span>
</div>              |  </div>  
```