### PR TITLE
fix: diff and dumpXTree return type

### DIFF
--- a/src/XTreeDiffPlus.ts
+++ b/src/XTreeDiffPlus.ts
@@ -138,10 +138,10 @@ export abstract class XTreeDiffPlus<T = any, S= any> {
   /**
    * run diff algorithm
    *
-   * @returns {{ oldTree: S; newTree: S }}
+   * @returns {{ oldTree: XTree<S>; newTree: XTree<S> }}
    * @memberof XTreeDiffPlus
    */
-  diff(): { oldTree: S; newTree: S } {
+  diff(): ReturnType<XTreeDiffPlus<T, S>['dumpXTree']> {
     const { rawOld, rawMew } = this;
     const T_old = this.buildXTree(rawOld);
     const T_new = this.buildXTree(rawMew);
@@ -390,5 +390,5 @@ export abstract class XTreeDiffPlus<T = any, S= any> {
    * @returns {{ oldTree: any; newTree: any }}
    * @memberof XTreeDiffPlus
    */
-  public abstract dumpXTree(oldTree: XTree<S>, newTree: XTree<S>): { oldTree: any; newTree: any };
+  public abstract dumpXTree(oldTree: XTree<S>, newTree: XTree<S>): { oldTree: XTree<S>; newTree: XTree<S> };
 }


### PR DESCRIPTION
Hey, here is a small update of the type definitions.
Please be aware that I don’t fully understand the algorithm and not sure of the real purpose of `dumpXTree`. I might miss something – unlikely – that invalidates my fix.
[This implementation](https://github.com/SubZtep/vite-plugin-pug/blob/dfc3d9db0bea0b6c5fb806d0cc9d0b79a60bc2b5/scripts/forest.ts) has no type error with my changes.
Thank you!